### PR TITLE
Add support for separate environments for status results - K8s drop-down selection

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg?sanitize=true"
   display_name: Prometheus
   sub_title: Monitoring
   project_url: "https://github.com/prometheus/prometheus"

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -74,6 +74,7 @@ container:
           mkdir -p .builds/linux-amd64
           cp ./prometheus  .builds/linux-amd64/
           cp ./promtool .builds/linux-amd64/
+          sleep 100000
           make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
           echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -85,6 +85,7 @@ container:
           rm ./Dockerfile
           rm ./Makefile
           rm ./Makefile.common
+          rm ./.dockerignore
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Makefile
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Makefile.common

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -24,7 +24,7 @@ before_script:
 
 compile:
   # image: crosscloudci/debian-go:1.11.4-stretch
-  image: crosscloudci/debian-docker
+  image: crosscloudci/debian-docker-go:latest
   stage: Build
   variables:
     CGO_ENABLED: '1'

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -23,7 +23,8 @@ before_script:
   - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
-  image: crosscloudci/debian-go:1.11.4-stretch
+  # image: crosscloudci/debian-go:1.11.4-stretch
+  image: crosscloudci/debian-docker
   stage: Build
   variables:
     CGO_ENABLED: '1'

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -72,8 +72,8 @@ container:
         if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
           # If building master tag & push based on the new make file
           mkdir -p .build/linux-amd64
-          cp ./prometheus  .builds/linux-amd64/
-          cp ./promtool .builds/linux-amd64/
+          cp ./prometheus  .build/linux-amd64/
+          cp ./promtool .build/linux-amd64/
           make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
           echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -35,6 +35,7 @@ compile:
         make promu
         promu crossbuild -v
         docker run --privileged linuxkit/binfmt:v0.6
+        IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
         make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64" || true
         sleep 1000000
       else

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -71,10 +71,9 @@ container:
         echo 'Default to amd64 (Intel)'
         if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
           # If building master tag & push based on the new make file
-          mkdir -p .builds/linux-amd64
+          mkdir -p .build/linux-amd64
           cp ./prometheus  .builds/linux-amd64/
           cp ./promtool .builds/linux-amd64/
-          sleep 100000
           make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
           echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -92,8 +92,7 @@ container:
         fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6
-        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64" || true
-        sleep 1000000
+        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64"
         docker tag $CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG $CI_REGISTRY_IMAGE:$IMAGE_TAG
         echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
         echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -81,9 +81,11 @@ container:
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
         if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
-          # Fetch head make file(has arm64 support).
+          # Fetch head make & docker file(has arm64 support).
           rm ./Dockerfile
+          rm ./Makefile
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
+          wget https://raw.githubusercontent.com/prometheus/prometheus/master/Makefile
         fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -28,6 +28,15 @@ compile:
   variables:
     CGO_ENABLED: '1'
   script:
+    - >
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64'
+        make promu
+        promu crossbuild -v
+        sleep 1000000
+      else
+        continue
+      fi
     - sed -i -e "\$areplace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" ./go.mod
     - sed -i '5s|.*|github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=|' ./go.sum
     - ln -s /builds /go/src/github.com

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -35,18 +35,18 @@ compile:
         promu crossbuild -v
       else
         echo 'Default to amd64 (Intel)'
-        # ln -s /builds /go/src/github.com
-        # cd /go/src/github.com/prometheus/prometheus
-        if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
-          GO111MODULE=on go mod download 
-        else
           make -j $(getconf _NPROCESSORS_ONLN) deps
+          make -j $(getconf _NPROCESSORS_ONLN) build
+          make -j $(getconf _NPROCESSORS_ONLN) test
+        if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
+          # If building master copy bins to new .build dir
+          mkdir -p .builds/linux-amd64
+          cp ./prometheus  .builds/linux-amd64
+          cp ./promtool .builds/linux-amd64/
+        else
+          exit 0
         fi
-        make -j $(getconf _NPROCESSORS_ONLN) build
-        make -j $(getconf _NPROCESSORS_ONLN) test
       fi
-    #- sed -i -e "\$areplace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" ./go.mod
-    #- sed -i '5s|.*|github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=|' ./go.sum
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -55,9 +55,8 @@ compile:
 
 container:
   stage: Package
-  image: crosscloudci/debian-docker
+  image: crosscloudci/debian-docker-go:latest
   script:
-    - apt update && apt install -y make
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
     - >
       if [ "$ARCH" == "arm64" ]; then
@@ -71,10 +70,10 @@ container:
       else
         echo 'Default to amd64 (Intel)'
         make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
-        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
+        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
         echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
         docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-        docker push "$CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG"
+        docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
       fi
     - cat release.env
   dependencies:

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -91,7 +91,8 @@ container:
         fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6
-        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64"
+        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64" || true
+        sleep 1000000
         docker tag $CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG $CI_REGISTRY_IMAGE:$IMAGE_TAG
         echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
         echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -57,18 +57,20 @@ container:
   stage: Package
   image: crosscloudci/debian-docker-go:latest
   script:
-    - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
     - >
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
+        IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6
         make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64"
-        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-arm64\" | tee release.env
+        docker tag $CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG $CI_REGISTRY_IMAGE:$IMAGE_TAG
+        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
         echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
         docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
         docker push "$CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG"
       else
         echo 'Default to amd64 (Intel)'
+        IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
         if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
           # If building master tag & push based on the new make file
           mkdir -p .build/linux-amd64

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -82,6 +82,7 @@ container:
         echo 'ARCH set to arm64'
         if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
           # Fetch head make file(has arm64 support).
+          rm ./Dockerfile
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
         fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -23,7 +23,6 @@ before_script:
   - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
 
 compile:
-  # image: crosscloudci/debian-go:1.11.4-stretch
   image: crosscloudci/debian-docker-go:latest
   stage: Build
   variables:
@@ -34,25 +33,20 @@ compile:
         echo 'ARCH set to arm64'
         make promu
         promu crossbuild -v
-        docker run --privileged linuxkit/binfmt:v0.6
-        IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
-        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64" || true
-        sleep 1000000
       else
-        continue
+        echo 'Default to amd64 (Intel)'
+        # ln -s /builds /go/src/github.com
+        # cd /go/src/github.com/prometheus/prometheus
+        if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
+          GO111MODULE=on go mod download 
+        else
+          make -j $(getconf _NPROCESSORS_ONLN) deps
+        fi
+        make -j $(getconf _NPROCESSORS_ONLN) build
+        make -j $(getconf _NPROCESSORS_ONLN) test
       fi
-    - sed -i -e "\$areplace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" ./go.mod
-    - sed -i '5s|.*|github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=|' ./go.sum
-    - ln -s /builds /go/src/github.com
-    - cd /go/src/github.com/prometheus/prometheus
-    - >
-      if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
-        GO111MODULE=on go mod download 
-      else
-        make -j $(getconf _NPROCESSORS_ONLN) deps
-      fi
-    - make -j $(getconf _NPROCESSORS_ONLN) build
-    - make -j $(getconf _NPROCESSORS_ONLN) test
+    #- sed -i -e "\$areplace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" ./go.mod
+    #- sed -i '5s|.*|github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=|' ./go.sum
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -65,11 +59,23 @@ container:
   script:
     - apt update && apt install -y make
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}
-    - make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG"
-    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-    - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
-    - echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
-    - echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
+    - >
+      if [ "$ARCH" == "arm64" ]; then
+        echo 'ARCH set to arm64'
+        docker run --privileged linuxkit/binfmt:v0.6
+        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64"
+        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-arm64\" | tee release.env
+        echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
+        docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+        docker push "$CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG"
+      else
+        echo 'Default to amd64 (Intel)'
+        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
+        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
+        echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
+        docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+        docker push "$CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG"
+      fi
     - cat release.env
   dependencies:
     - compile

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -84,8 +84,10 @@ container:
           # Fetch head make & docker file(has arm64 support).
           rm ./Dockerfile
           rm ./Makefile
+          rm ./Makefile.common
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
           wget https://raw.githubusercontent.com/prometheus/prometheus/master/Makefile
+          wget https://raw.githubusercontent.com/prometheus/prometheus/master/Makefile.common
         fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -69,18 +69,19 @@ container:
         docker push "$CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG"
       else
         echo 'Default to amd64 (Intel)'
-        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
         if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
           # If building master tag & push based on the new make file
           mkdir -p .builds/linux-amd64
           cp ./prometheus  .builds/linux-amd64/
           cp ./promtool .builds/linux-amd64/
+          make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
           echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
           docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
           docker push "$CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG"
         else
           # Tag/Push using old make file model
+          make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
           echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
           docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -67,7 +67,7 @@ container:
         echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
         echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
         docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-        docker push "$CI_REGISTRY_IMAGE-linux-arm64:$IMAGE_TAG"
+        docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
       else
         echo 'Default to amd64 (Intel)'
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -34,6 +34,8 @@ compile:
         echo 'ARCH set to arm64'
         make promu
         promu crossbuild -v
+        docker run --privileged linuxkit/binfmt:v0.6
+        make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64" || true
         sleep 1000000
       else
         continue

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -30,6 +30,10 @@ compile:
   script:
     - >
       if [ "$ARCH" == "arm64" ]; then
+        if [ "$CI_COMMIT_REF_NAME" !== "master" ]; then
+          # Fetch head make file(has arm64 support).
+          wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
+        fi
         echo 'ARCH set to arm64'
         # Disable all architectures, except for arm64.
         sed -i -e '/ linux\/amd64/ s/^/#/' .promu.yml 

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -29,7 +29,6 @@ compile:
   variables:
     CGO_ENABLED: '1'
   script:
-    - apt update && apt install make
     - >
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -70,10 +70,22 @@ container:
       else
         echo 'Default to amd64 (Intel)'
         make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
-        echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
-        echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
-        docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-        docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+        if [ "$CI_COMMIT_REF_NAME" = "master" ]; then
+          # If building master tag & push based on the new make file
+          mkdir -p .builds/linux-amd64
+          cp ./prometheus  .builds/linux-amd64/
+          cp ./promtool .builds/linux-amd64/
+          echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
+          echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
+          docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+          docker push "$CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG"
+        else
+          # Tag/Push using old make file model
+          echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
+          echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
+          docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+          docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
+        fi
       fi
     - cat release.env
   dependencies:

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -75,10 +75,11 @@ container:
           cp ./prometheus  .build/linux-amd64/
           cp ./promtool .build/linux-amd64/
           make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"
-          echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE-linux-amd64\" | tee release.env
+          docker tag $CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG $CI_REGISTRY_IMAGE:$IMAGE_TAG
+          echo export IMAGE_ARGS=\"--set server.image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
           echo export TAG_ARGS=\"--set server.image.tag=$IMAGE_TAG\" | tee -a release.env
           docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-          docker push "$CI_REGISTRY_IMAGE-linux-amd64:$IMAGE_TAG"
+          docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
         else
           # Tag/Push using old make file model
           make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="amd64"

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -29,6 +29,7 @@ compile:
   variables:
     CGO_ENABLED: '1'
   script:
+    - apt update && apt install make
     - >
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -30,10 +30,6 @@ compile:
   script:
     - >
       if [ "$ARCH" == "arm64" ]; then
-        if [ "$CI_COMMIT_REF_NAME" !== "master" ]; then
-          # Fetch head make file(has arm64 support).
-          wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
-        fi
         echo 'ARCH set to arm64'
         # Disable all architectures, except for arm64.
         sed -i -e '/ linux\/amd64/ s/^/#/' .promu.yml 
@@ -84,6 +80,10 @@ container:
     - >
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
+        if [ "$CI_COMMIT_REF_NAME" != "master" ]; then
+          # Fetch head make file(has arm64 support).
+          wget https://raw.githubusercontent.com/prometheus/prometheus/master/Dockerfile
+        fi
         IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.arm64
         docker run --privileged linuxkit/binfmt:v0.6
         make -j $(getconf _NPROCESSORS_ONLN) docker DOCKER_REPO="$CI_REGISTRY" DOCKER_IMAGE_NAME="$CI_PROJECT_NAME/$CI_PROJECT_NAME" DOCKER_IMAGE_TAG="$IMAGE_TAG" DOCKER_ARCHS="arm64"

--- a/server/.gitlab-ci.yml
+++ b/server/.gitlab-ci.yml
@@ -31,6 +31,26 @@ compile:
     - >
       if [ "$ARCH" == "arm64" ]; then
         echo 'ARCH set to arm64'
+        # Disable all architectures, except for arm64.
+        sed -i -e '/ linux\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ linux\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ darwin\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ darwin\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ windows\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ windows\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ freebsd\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ freebsd\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ openbsd\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ openbsd\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ netbsd\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ netbsd\/386/ s/^/#/' .promu.yml 
+        sed -i -e '/ dragonfly\/amd64/ s/^/#/' .promu.yml 
+        sed -i -e '/ linux\/arm$/ s/^/#/' .promu.yml 
+        sed -i -e '/ freebsd\/arm/ s/^/#/' .promu.yml 
+        sed -i -e '/ netbsd\/arm/ s/^/#/' .promu.yml 
+        sed -i -e '/ linux\/ppc64/ s/^/#/' .promu.yml 
+        sed -i -e '/ linux\/ppc64/ s/^/#/' .promu.yml 
+        sed -i -e '/ linux\/s390x/ s/^/#/' .promu.yml 
         make promu
         promu crossbuild -v
       else


### PR DESCRIPTION
This ticket is needed for https://github.com/crosscloudci/ci_status_repository/pull/18