### PR TITLE
update logo w/ project directory URL

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg?sanitize=true"
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/icon/color/prometheus-icon-color.svg?sanitize=true"
   display_name: Prometheus
   sub_title: Monitoring
   project_url: "https://github.com/prometheus/prometheus"


### PR DESCRIPTION
https://github.com/crosscloudci/ci-dashboard/issues/90

Changes made: add /projects/ to URL

  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/icon/color/prometheus-icon-color.svg?sanitize=true"