### PR TITLE
enable Prometheus v2.11.0

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.10.0"
+  stable_ref: "v2.11.0"
   head_ref: "master"


### PR DESCRIPTION
Following process in https://github.com/crosscloudci/crosscloudci/blob/master/CONTRIBUTING.md#updating-release-details: 

- Create a new branch to make updates
- Update content, as needed:
   - stable_ref: "v2.11.0"
- Submit a pull request to master branch
- Tag reviewers as CNCF.CI project maintainers: @denverwilliams, @lixuna, @taylor, @wavell 