### PR TITLE
Enable Prometheus v2.11.0 on production 

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.10.0"
+  stable_ref: "v2.11.0"
   head_ref: "master"


### PR DESCRIPTION
- Enable Prometheus v2.11.0 on production (cncf.ci) via prometheus-configuration production branch
- crosscloudci/crosscloudci#159