### PR TITLE
enable Prometheus v2.11.1 on cncf.ci

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.11.0"
+  stable_ref: "v2.11.1"
   head_ref: "master"


### PR DESCRIPTION
enable Prometheus v2.11.1
- released 2019-07-10
- Build passed on staging