### PR TITLE
enable Prometheus v2.11.2 on cidev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.11.1"
+  stable_ref: "v2.11.2"
   head_ref: "master"


### PR DESCRIPTION
- enable Prometheus v2.11.2
- released on Aug 14, 2019