### PR TITLE
enable Prometheus 2.12.0 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.11.1"
+  stable_ref: "v2.12.0"
   head_ref: "master"


### PR DESCRIPTION
- enable Prometheus 2.12.0
- released on Aug 18, 2019