### PR TITLE
prometheus v2.19.2 stable to integration

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.19.1"
+  stable_ref: "v2.19.2"
   head_ref: "master"


### PR DESCRIPTION
## Description
- v2.19.2  was released on 06/26/2020
- update stable on integration for dev.cncf.ci

## Issues:

https://github.com/vulk/cncf_ci/issues/71

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [ ]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
