### PR TITLE
Update prometheus stable v2.19.3 to staging

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.19.2"
+  stable_ref: "v2.19.3"
   head_ref: "master"


### PR DESCRIPTION
## Description
  - v2.19.3 was released on 07-24-2020
  - update stable on staging
  - passes trigger builds on dev: https://gitlab.dev.cncf.ci/prometheus/prometheus/-/jobs/201748

## Issues:

https://github.com/vulk/cncf_ci/issues/71

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Manual testing on gitlab.dev.cncf.ci
 - [ ]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [ ]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
