### PR TITLE
Update prometheus stable to v2.21.0 on production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.20.1"
+  stable_ref: "v2.21.0"
   head_ref: "master"


### PR DESCRIPTION
## Description
  - v2.21.0 was released on 09/11/2020
  - update stable on production
  - passes staging trigger builds: https://gitlab.staging.cncf.ci/prometheus/prometheus/-/jobs/199930

## Issues:

https://github.com/vulk/cncf_ci/issues/71

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x] Manual pipeline build test on dev.cncf.ci
 - [x]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [x]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required