### PR TITLE
Update promethus stable v2.22.1 on production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.22.0"
+  stable_ref: "v2.22.1"
   head_ref: "master"


### PR DESCRIPTION
## Description
 - v2.22.1 was released on 11/03/2020
 - update stable on production
 - passes staging trigger: https://gitlab.staging.cncf.ci/prometheus/prometheus/-/jobs/201442

## Issues:

https://github.com/vulk/cncf_ci/issues/71

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x] Tested manual on dev.cncf.ci
 - [x]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
