### PR TITLE
Update Stable to v2.24.0 on dev (integration)

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v2.23.0"
+  stable_ref: "v2.24.0"
   head_ref: "master"


### PR DESCRIPTION
## Description
  - v2.24.0 was released on 01/06/2021
  - update stable on dev
  - manually passes build pipeline after deleteing cached docker image causing errors: https://gitlab.dev.cncf.ci/prometheus/prometheus/-/jobs/205518
  
## Issues:

https://github.com/vulk/cncf_ci/issues/71

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
